### PR TITLE
Rename Pension kit's UpdatePayrollContributions -> ReportPayrollContributions

### DIFF
--- a/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
@@ -56,7 +56,7 @@ class PayrunInfo:
 class PayrollUploadSettings:
     """
     This is the one of the params for "format_contributions" and "format_contribution" method in the
-    UpdatePayrollContributions interface.
+    ReportPayrollContributions interface.
     """
     """
     env: This field denotes the app environments. TS denotes the Testing environment and AP denotes the live environment 

--- a/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
@@ -59,7 +59,7 @@ class PayrollUploadSettings:
     ReportPayrollContributions interface.
     """
     """
-    env: This field denotes the app environments. TS denotes the Testing environment and AP denotes the live environment 
+    env: This field denotes the app environments. TS denotes the Testing environment and AP denotes the live environment
          for the App
     """
     environment: str

--- a/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
@@ -52,13 +52,15 @@ class PayrunInfo:
     """
     pay_frequency: Optional[str]
 
+
 class PayrollUploadSettings:
     """
-    This is the one of the params for "format_contributions" and "format_contribution" method in the ReportPayrollContributions
-    interface.
+    This is the one of the params for "format_contributions" and "format_contribution" method in the
+    UpdatePayrollContributions interface.
     """
     """
-    env: This field denotes the app enviroments. TS denotes the Testing enviroment and AP denotes the live enviroment for the App
+    env: This field denotes the app environments. TS denotes the Testing environment and AP denotes the live environment 
+         for the App
     """
     environment: str
     """
@@ -81,7 +83,6 @@ class PayrollUploadSettings:
     customer_partner_settings: This dict contains the settings value specified on manifest in key-value pair
     """
     customer_partner_settings: dict
-
 
 
 class PayrollRunContribution:
@@ -185,6 +186,3 @@ class EmployeePayrollRecord:
     eoy_info: This field indicates the value of the eoy info for the employee
     """
     eoy_info: Optional[EoyInfo]
-
-
-

--- a/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
@@ -12,8 +12,6 @@ class ReportPayrollContributions(ABC):
     This class represents the "update payroll contribution" capability. The developer is supposed to implement
     format_contributions method in their implementation. For further details regarding their
     implementation details, check their documentation.
-
-    A instance of this class cannot be initiated unless either of these 2 methods are implemented.
     """
 
     @staticmethod

--- a/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
@@ -9,7 +9,7 @@ from flux_sdk.pension.capabilities.report_payroll_contributions.data_models impo
 
 class ReportPayrollContributions(ABC):
     """
-    This class represents the "update payroll contribution" capability. The developer is supposed to implement
+    This class represents the "report payroll contribution" capability. The developer is supposed to implement
     format_contributions method in their implementation. For further details regarding their
     implementation details, check their documentation.
     """

--- a/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/interface.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from flux_sdk.flux_core.data_models import File
 from flux_sdk.pension.capabilities.report_payroll_contributions.data_models import (
     EmployeePayrollRecord,
     PayrollUploadSettings,
@@ -17,20 +18,13 @@ class ReportPayrollContributions(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_file_name(payroll_upload_settings: PayrollUploadSettings) -> str:
-        """
-        This method receives a PayrollUploadSettings from which the developer is expected to return file name based on payroll_upload_settings
-        :param payroll_upload_settings:
-        :return: str
-        """
-
-    @staticmethod
-    @abstractmethod
     def format_contributions(employee_payroll_records: list[EmployeePayrollRecord],
-                             payroll_upload_settings: PayrollUploadSettings) -> bytes:
+                             payroll_upload_settings: PayrollUploadSettings) -> File:
         """
-        This method receives a list of EmployeePayrollRecord. The developer is expected to return the bytes of the formatted contributions
+        Given a list of EmployeePayrollRecord and the PayrollUploadSettings, prepare a file for upload to the pension
+        provider.  The file will be sent verbatim, so any compression or other formatting required by the pension
+        provider must be applied within this function.
         :param employee_payroll_records:
         :param payroll_upload_settings:
-        :return: bytes
+        :return: File
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.1"
+version = "0.2"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
Also: combine the get file name hook with the format contributions hook to
      avoid chatter between rippling and third party code

This name change is to better reflect the direction of information flow as we're not actually updating anything within Rippling.