### PR TITLE
APPS-22126 Transamerica PR review related changes to company name

### DIFF
--- a/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
+++ b/flux_sdk/pension/capabilities/report_payroll_contributions/data_models.py
@@ -83,7 +83,10 @@ class PayrollUploadSettings:
     customer_partner_settings: This dict contains the settings value specified on manifest in key-value pair
     """
     customer_partner_settings: dict
-
+    """
+        company_name: This field denotes the Company Name
+    """
+    company_name: str
 
 class PayrollRunContribution:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.2"
+version = "0.3"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
Adding a company name field (that will use the Company name computed based on PEO, etc) to the payroll upload settings to be used in addition to the company legal name