### PR TITLE
Fix codeowners syntax and cascading

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/*                                          @Rippling/apps
-/flux-sdk/*                                 @Rippling/flux
+*            @Rippling/apps
+/flux-sdk/   @Rippling/flux @Rippling/apps


### PR DESCRIPTION
Improper use of wildcards wasn't matching nested directories, and the flux-sdk match was overriding the global check