### PR TITLE
Bump version for FSA plan type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.11"
+version = "0.12"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
https://rippling.atlassian.net/browse/INSURANCE-68090

Bump version for https://github.com/Rippling/flux-sdk/pull/37 , which was bumped, but got collides when it's merged to main