### PR TITLE
ETL Kit: use typing.NewType for type aliases so typing is retained at runtime

### DIFF
--- a/flux_sdk/etl/data_models/query.py
+++ b/flux_sdk/etl/data_models/query.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, NewType, Optional, Union
 
 from flux_sdk.flux_core.validation import check_field
 
@@ -12,7 +12,7 @@ class Connector(Enum):
     MONGODB = "mongodb"
 
 
-SQLQueryArg = Union[str, bool, int, float, datetime, date, time]
+SQLQueryArg = NewType("SQLQueryArg", Union[str, bool, int, float, datetime, date, time])
 """This is the reduced list of acceptable types that can be used as SQL arguments."""
 
 
@@ -80,5 +80,5 @@ class MongoQuery:
         check_field(self, "aggregate", list[dict[str, Any]])
 
 
-Query = Union[SQLQuery, MongoQuery]
+Query = NewType("Query", Union[SQLQuery, MongoQuery])
 """This is the list of types that can be used to represent a query."""

--- a/flux_sdk/etl/data_models/record.py
+++ b/flux_sdk/etl/data_models/record.py
@@ -1,16 +1,16 @@
 from dataclasses import dataclass
 from datetime import date, datetime, time
-from typing import Optional, Union
+from typing import NewType, Optional, Union
 
 from flux_sdk.flux_core.validation import check_field
 
-Field = Union[str, int, float, bool, date, time, datetime, None]
+Field = NewType("Field", Union[str, int, float, bool, date, time, datetime, None])
 """
 This represents the currently supported types for Record fields. Currently, we only support these primitive types and do
 not allow for any complex/nested types.
 """
 
-Checkpoint = Union[datetime, int, str]
+Checkpoint = NewType("Checkpoint", Union[datetime, int, str])
 """
 Checkpoints can be represented as either timestamp (datetime), sequence number (int) or an opaque token (str). Values
 are compared assuming an increasing sort order, so the largest value in a sync will be treated as the high-water mark

--- a/flux_sdk/etl/data_models/schema.py
+++ b/flux_sdk/etl/data_models/schema.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Union
+from typing import NewType, Optional, Union
 
 from flux_sdk.flux_core.validation import check_field
 
@@ -115,7 +115,7 @@ class EmployeeReference:
         check_field(self, "description", str)
 
 
-Reference = Union[CustomObjectReference, EmployeeReference]
+Reference = NewType("Reference", Union[CustomObjectReference, EmployeeReference])
 """This lists the available types that can be used for schema references."""
 
 


### PR DESCRIPTION
This PR updates the syntax for creating type aliases such that the variable type names are preserved at runtime.

Type alias information is lost at runtime when using the more standard type alias syntax like:

```
SQLQueryArg = Union[str, bool, int, float, datetime, date, time]
```

Tools that use introspection will not see type annotations of `SQLQueryArg` but will see the union type that has been aliased instead.

Using a different syntax, we can ensure that introspection-based tools can still see type per the original type declaration.
```
SQLQueryArg = NewType("SQLQueryArg", Union[str, bool, int, float, datetime, date, time])
```

Validation and tests were updated because now there is an extra step required to go from type alias to the concrete type definition.

