### PR TITLE
Add imputed income to ben admin kit data models

### DIFF
--- a/flux_sdk/benefits_administration/capabilities/process_employees_deductions/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/process_employees_deductions/data_models.py
@@ -11,10 +11,12 @@ class DeductionDetails:
     end_date: datetime | None
     employee_contribution: Decimal | None
     company_contribution: Decimal | None
+    imputed_income: Decimal | None
 
 class DeductionCodeField(Enum):
     EMPLOYEE_CONTRIBUTION = "EMPLOYEE_CONTRIBUTION"
     COMPANY_CONTRIBUTION = "COMPANY_CONTRIBUTION"
+    IMPUTED_INCOME = "IMPUTED_INCOME"
 
 class ExternalDeductionCodeToRipplingCode:
     external_code: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.35"
+version = "0.36"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
 version = "0.36"
+
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
 version = "0.36"
-
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
https://rippling.atlassian.net/browse/BENPNP-1129

This diff adds support in the ben admin kit data model for imputed income to be handled apart from EE and company contributions