### PR TITLE
Add phone_number_v2

### DIFF
--- a/flux_sdk/flux_core/data_models.py
+++ b/flux_sdk/flux_core/data_models.py
@@ -64,6 +64,14 @@ class MaritalStatus(Enum):
     PERMANENTLY_SEPARATED = 4
     REGISTERED_PARTNERSHIP = 5
 
+class PhoneNumber:
+    """
+    This contains the details of an international phone number.
+    """
+    country_code: str
+    national_number: str
+    extension: Optional[str]
+
 
 class Employee:
     """
@@ -90,6 +98,7 @@ class Employee:
     status: EmployeeState
     dob: datetime
     phone_number: str
+    phone_number_v2: PhoneNumber
     is_temporary: bool
     is_hourly: bool
     is_salaried: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.36"
+version = "0.37"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
https://rippling.atlassian.net/browse/BENPNP-1359

This diff adds the `phone_number_v2` field to `Employee` to support an object representation of international phone numbers. This mirrors the HRIS support here https://github.com/Rippling/rippling-main/blob/master/app/hub/models/phone_number.py#L12