### PR TITLE
BENPNP-3020: fix: typo in JobDetail attribute company_employment_type

### DIFF
--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -79,7 +79,7 @@ class JobDetails:
     """ The employees location """
     location: Optional[WorkLocation]
     """ The Company Configured Employment Type"""
-    companyEmploymentType: Optional[str]
+    company_employment_type: Optional[str]
 
 
 class Employment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.44"
+version = "0.45"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fix typo in company_employment_type attribute of JobDetail model

PR with typo : https://github.com/Rippling/flux-sdk/pull/105