### PR TITLE
Adds dynamic fields for specific vendors

### DIFF
--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -122,6 +122,10 @@ class EmployeeStatus:
     """ The date when the employee entered this status """
     effective_date: datetime
 
+class DynamicFields:
+    field_name: str
+    field_value: str
+
 class EmployeeHrData:
     '''
     This contains the core data about an employee
@@ -147,6 +151,9 @@ class EmployeeHrData:
     status: EmployeeStatus
     """ Whether or not the employee is considered eligible for benefits """
     benefits_eligibility: BenefitsEligibilityStatus
+    """ Dynamic Fields for the Vendor """
+    dynamic_fields: list[DynamicFields]
+
 
 
 

--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -122,7 +122,7 @@ class EmployeeStatus:
     """ The date when the employee entered this status """
     effective_date: datetime
 
-class DynamicFields:
+class VendorCustomFields:
     field_name: str
     field_value: str
 
@@ -152,7 +152,7 @@ class EmployeeHrData:
     """ Whether or not the employee is considered eligible for benefits """
     benefits_eligibility: BenefitsEligibilityStatus
     """ Dynamic Fields for the Vendor """
-    dynamic_fields: list[DynamicFields]
+    vendor_custom_fields: list[VendorCustomFields]
 
 
 


### PR DESCRIPTION
Problem Statement: 

We have some user defined custom fields defined for companies in the CustomFieldsV2  Model, some vendors (namely Plansource) desire the values of these field for each role, and this needs to be passed to flux-apps, so as to include them in the Census File. 

The Changes allow us to pass the Custom Field Names and their values to flux-apps. 


