### PR TITLE
BENPNP-3420: add work location nickname and perm profile

### DIFF
--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -103,6 +103,8 @@ class Employment:
     original_hire_date: datetime
     """ The date the employee will begin to be paid with the company """
     w2_start_date: datetime
+    """ The permanent profile number """
+    permanent_profile_number: str
     
 
 class BenefitsEligibility(Enum):

--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -103,7 +103,7 @@ class Employment:
     original_hire_date: datetime
     """ The date the employee will begin to be paid with the company """
     w2_start_date: datetime
-    """ The permanent profile number """
+    """ The permanent profile number - unique across roles at same company """
     permanent_profile_number: str
     
 

--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -104,7 +104,7 @@ class Employment:
     """ The date the employee will begin to be paid with the company """
     w2_start_date: datetime
     """ The permanent profile number - unique across rehired roles at same company """
-    permanent_profile_number: str
+    permanent_profile_number: Optional[str]
     
 
 class BenefitsEligibility(Enum):

--- a/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
+++ b/flux_sdk/benefits_administration/capabilities/report_employees_hr_data/data_models.py
@@ -103,7 +103,7 @@ class Employment:
     original_hire_date: datetime
     """ The date the employee will begin to be paid with the company """
     w2_start_date: datetime
-    """ The permanent profile number - unique across roles at same company """
+    """ The permanent profile number - unique across rehired roles at same company """
     permanent_profile_number: str
     
 

--- a/flux_sdk/flux_core/data_models.py
+++ b/flux_sdk/flux_core/data_models.py
@@ -150,6 +150,8 @@ class WorkLocation:
     zip_code: Optional[str]
     """ Date since when the employee has been working at this location """
     effective_date: Optional[datetime]
+    """ Nickname of work location """
+    nickname: Optional[str]
 
 class Department:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.47"
+version = "0.48"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
JIRA: https://rippling.atlassian.net/browse/BENPNP-3420
Description:
Added 2 fields:

- permanent_profile_number - corresponds to unique id for a person across multiple roles in the same company
- work_location.nickname - manually provided nickname for a work location