### PR TITLE
Add support for report field names in Report data

### DIFF
--- a/flux_sdk/flux_core/data_models.py
+++ b/flux_sdk/flux_core/data_models.py
@@ -264,12 +264,20 @@ class File:
     name: str
     content: bytes
 
+class ReportField:
+    """
+    Represents each field in a report exported data.
+    """
+    field_id: str
+    field_name: str
+    value: Any
+
 class ReportRow:
     """
     Represents each row in a report exported data.
     """
 
-    fields: dict[str, Any]
+    fields: list[ReportField]
 
 class ReportData:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.58"
+version = "0.59"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
This is a breaking change. but since none of the apps in production using it. It is safe to change now.