### PR TITLE
Fix incorrect snake_case conversion for YTD in interface name

### DIFF
--- a/flux_sdk/payroll/report_employee_ytd_data/interface.py
+++ b/flux_sdk/payroll/report_employee_ytd_data/interface.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from flux_sdk.flux_core.data_models import File, ReportData
 
 
-class ReportEmployeeYTDData(ABC):
+class ReportEmployeeYtdData(ABC):
     @staticmethod
     @abstractmethod
     def format_employee_ytd_data(employee_ytd_data: ReportData) -> File:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.59"
+version = "0.60"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Payroll PR Checklist

## Artifacts
(Capture the relevant artifacts in this section. Please update as "N/A" if not required)

- **JIRA:** 
- **Incident Link:** 
- **Slack Thread:** 
- **Documentation/Wiki:** N/A

## Why is this change needed?
While developing the payroll kit, I discovered that interface names are automatically converted to snake_case. As a result, ReportEmployeeYTDData was incorrectly transformed into report_employee_y_t_d, causing module resolution to fail.
✅ This PR resolves the issue by updating the class name to ReportEmployeeYtdData, ensuring consistent and correct formatting.

## ChangeLog
- `flux_sdk/payroll/report_employee_ytd_data/interface.py` - Renaming the ReportEmployeeYTDData interface to ReportEmployeeYtdData
- `pyproject.toml` - Bumping the version of flux-sdk

## Test Plan
- I've tested it locally and it works as expected. 

## Note for Reviewers
- NA

## To Do / Next Steps
- NA

## Rollback plan
- [x] Check this box if this PR can be safely reverted.
- [ ] Check this box if this PR CANNOT be safely reverted.