### PR TITLE
add enrollment_state to EmployeeEnrollment class

### DIFF
--- a/flux_sdk/flex/capabilities/update_enrollments/data_models.py
+++ b/flux_sdk/flex/capabilities/update_enrollments/data_models.py
@@ -81,3 +81,4 @@ class EmployeeEnrollment:
     department: Optional[str]
     hsa_annual_limit_type: Optional[str]
     record_sent_timestamp: Optional[date]
+    enrollment_state: Optional[str]


### PR DESCRIPTION
This pull request includes a small change to the `EmployeeEnrollment` class in the `flux_sdk/flex/capabilities/update_enrollments/data_models.py` file. The change introduces an optional `enrollment_state` field to the data model.

* [`flux_sdk/flex/capabilities/update_enrollments/data_models.py`](diffhunk://#diff-a2d286f25852c059d66aee92202b2e70cc0d27fe1fe3776bf9b49c7507117352R84): Added the `enrollment_state` field to the `EmployeeEnrollment` class.