### PR TITLE
Add enum type for benefits

### DIFF
--- a/flux_sdk/insurance_broker/capabilities/report_employee_enrollments_to_cobra_provider/data_models.py
+++ b/flux_sdk/insurance_broker/capabilities/report_employee_enrollments_to_cobra_provider/data_models.py
@@ -263,6 +263,8 @@ class EnrollmentEventReason(Enum):
     RENEGE_EMPLOYEMENT = "RENEGE_EMPLOYEMENT"
     """The employee has changed to part time hours"""
     CHANGE_TO_PART_TIME = "CHANGE_TO_PART_TIME"
+    """The reason cannot be found"""
+    UNKNOWN = "UNKNOWN"
 
 class EnrollmentEvent:
     """The event that created an enrollment"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-sdk"
-version = "0.61"
+version = "0.62"
 description = "Defines the interfaces and data-models used by Rippling Flux Apps."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
This diff adds a new enum value to the Benefits `EnrollmentEventReason` to cover any case where the reason is indeterminable. 
