### PR TITLE
add recordType in Employee Enrollment object

### DIFF
--- a/flux_sdk/flex/capabilities/update_enrollments/data_models.py
+++ b/flux_sdk/flex/capabilities/update_enrollments/data_models.py
@@ -12,6 +12,11 @@ class BenefitType(Enum):
     COMMUTER = 2
 
 
+class RecordType(Enum):
+    Participant = 0
+    Enrollment = 1
+
+
 # specify the family enrollment status for HSA
 class HSAFamilyType(Enum):
     UNSPECIFIED = 0
@@ -82,3 +87,4 @@ class EmployeeEnrollment:
     hsa_annual_limit_type: Optional[str]
     record_sent_timestamp: Optional[date]
     enrollment_state: Optional[str]
+    record_type = Optional[RecordType]


### PR DESCRIPTION
This pull request introduces a new `RecordType` enum and integrates it into the `EmployeeEnrollment` data model in the `flux_sdk/flex/capabilities/update_enrollments/data_models.py` file. These changes aim to enhance the flexibility and clarity of enrollment record classification.

### Additions to data models:

* Added a new `RecordType` enum with two values: `Participant` and `Enrollment`. This provides a standardized way to classify enrollment records. (`[flux_sdk/flex/capabilities/update_enrollments/data_models.pyR15-R19](diffhunk://#diff-a2d286f25852c059d66aee92202b2e70cc0d27fe1fe3776bf9b49c7507117352R15-R19)`)

### Integration into `EmployeeEnrollment`:

* Introduced a new attribute `record_type` of type `Optional[RecordType]` to the `EmployeeEnrollment` class, allowing each enrollment record to specify its type. (`[flux_sdk/flex/capabilities/update_enrollments/data_models.pyR90](diffhunk://#diff-a2d286f25852c059d66aee92202b2e70cc0d27fe1fe3776bf9b49c7507117352R90)`)